### PR TITLE
Encode DB name in replication rules

### DIFF
--- a/scripts/cluster.js
+++ b/scripts/cluster.js
@@ -74,8 +74,8 @@ Cluster.prototype._replicateSecurity = function (sourceDB, targetDB) {
 Cluster.prototype._replicateRawDB = function (sourceDB, targetDB) {
   var slouch = this._params.useTargetAPI ? this._targetSlouch : this._sourceSlouch;
   return slouch.db.replicate({
-    source: this._params.source + '/' + sourceDB,
-    target: this._params.target + '/' + targetDB
+    source: this._params.source + '/' + encodeURIComponent(sourceDB),
+    target: this._params.target + '/' + encodeURIComponent(targetDB)
   });
 };
 


### PR DESCRIPTION
Hello,

If a DB name contains a "/" character, replication fails with a db_not_found error.

Happy to add a test for this (I tested it locally in my situation), but I'm unsure how. Guidance is welcome to make the PR compliant.

Thank you for this repo and for your time!